### PR TITLE
Iter4

### DIFF
--- a/cmd/shortener/main.go
+++ b/cmd/shortener/main.go
@@ -1,18 +1,22 @@
 package main
 
 import (
+	"github.com/go-chi/chi/v5"
 	"github.com/halviet/shortener/internal/handlers"
+	"github.com/halviet/shortener/internal/storage"
 	"log"
 	"net/http"
 )
 
 func main() {
-	mux := http.NewServeMux()
+	store := storage.New()
 
-	mux.HandleFunc("POST /", handlers.ShortenURLHandle)
-	mux.HandleFunc("GET /{id}", handlers.GetURLHandle)
+	r := chi.NewRouter()
 
-	if err := http.ListenAndServe(":8080", mux); err != nil {
+	r.Post("/", handlers.ShortenURLHandle(store))
+	r.Get("/{id}", handlers.GetURLHandle(store))
+
+	if err := http.ListenAndServe(":8080", r); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/cmd/shortener/main.go
+++ b/cmd/shortener/main.go
@@ -1,3 +1,50 @@
 package main
 
-func main() {}
+import (
+	"io"
+	"log"
+	"net/http"
+)
+
+func main() {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("POST /", ShortenURLHandle)
+	mux.HandleFunc("GET /{id}", GetURLHandle)
+
+	if err := http.ListenAndServe(":8080", mux); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func ShortenURLHandle(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Only POST requests are allowed!", http.StatusMethodNotAllowed)
+		return
+	}
+
+	defer r.Body.Close()
+	_, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+	}
+
+	w.WriteHeader(http.StatusCreated)
+	w.Write([]byte("https://localhost:8080/EwHXdJfB"))
+}
+
+func GetURLHandle(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Only GET requests are allowed!", http.StatusMethodNotAllowed)
+		return
+	}
+
+	if r.PathValue("id") == "EwHXdJfB" {
+		w.Header().Set("Location", "https://practicum.yandex.ru")
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusTemporaryRedirect)
+		return
+	}
+
+	http.Error(w, "Incorrect request", http.StatusBadRequest)
+}

--- a/cmd/shortener/main.go
+++ b/cmd/shortener/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/go-chi/chi/v5"
+	"github.com/halviet/shortener/internal/config"
 	"github.com/halviet/shortener/internal/handlers"
 	"github.com/halviet/shortener/internal/storage"
 	"log"
@@ -9,14 +10,15 @@ import (
 )
 
 func main() {
-	store := storage.New()
+	cfg := config.New()
 
+	store := storage.New()
 	r := chi.NewRouter()
 
-	r.Post("/", handlers.ShortenURLHandle(store))
+	r.Post("/", handlers.ShortenURLHandle(store, cfg))
 	r.Get("/{id}", handlers.GetURLHandle(store))
 
-	if err := http.ListenAndServe(":8080", r); err != nil {
+	if err := http.ListenAndServe(cfg.Addr, r); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/cmd/shortener/main.go
+++ b/cmd/shortener/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"io"
+	"github.com/halviet/shortener/internal/handlers"
 	"log"
 	"net/http"
 )
@@ -9,42 +9,10 @@ import (
 func main() {
 	mux := http.NewServeMux()
 
-	mux.HandleFunc("POST /", ShortenURLHandle)
-	mux.HandleFunc("GET /{id}", GetURLHandle)
+	mux.HandleFunc("POST /", handlers.ShortenURLHandle)
+	mux.HandleFunc("GET /{id}", handlers.GetURLHandle)
 
 	if err := http.ListenAndServe(":8080", mux); err != nil {
 		log.Fatal(err)
 	}
-}
-
-func ShortenURLHandle(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		http.Error(w, "Only POST requests are allowed!", http.StatusMethodNotAllowed)
-		return
-	}
-
-	defer r.Body.Close()
-	_, err := io.ReadAll(r.Body)
-	if err != nil {
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-	}
-
-	w.WriteHeader(http.StatusCreated)
-	w.Write([]byte("https://localhost:8080/EwHXdJfB"))
-}
-
-func GetURLHandle(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
-		http.Error(w, "Only GET requests are allowed!", http.StatusMethodNotAllowed)
-		return
-	}
-
-	if r.PathValue("id") == "EwHXdJfB" {
-		w.Header().Set("Location", "https://practicum.yandex.ru")
-		w.Header().Set("Content-Type", "text/plain")
-		w.WriteHeader(http.StatusTemporaryRedirect)
-		return
-	}
-
-	http.Error(w, "Incorrect request", http.StatusBadRequest)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,11 @@
 module github.com/halviet/shortener
 
 go 1.22.4
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/go-chi/chi/v5 v5.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.9.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,11 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/go-chi/chi/v5 v5.1.0 h1:acVI1TYaD+hhedDJ3r54HyA6sExp3HfXq7QWEEY/xMw=
+github.com/go-chi/chi/v5 v5.1.0/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/app/url.go
+++ b/internal/app/url.go
@@ -1,0 +1,28 @@
+package app
+
+import "math/rand"
+
+const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+const (
+	letterIdxBits = 6                    // 6 bits to represent a letter index
+	letterIdxMask = 1<<letterIdxBits - 1 // All 1-bits, as many as letterIdxBits
+	letterIdxMax  = 63 / letterIdxBits   // # of letter indices fitting in 63 bits
+)
+
+func RandString(n int) string {
+	b := make([]byte, n)
+	// A rand.Int63() generates 63 random bits, enough for letterIdxMax letters!
+	for i, cache, remain := n-1, rand.Int63(), letterIdxMax; i >= 0; {
+		if remain == 0 {
+			cache, remain = rand.Int63(), letterIdxMax
+		}
+		if idx := int(cache & letterIdxMask); idx < len(letterBytes) {
+			b[i] = letterBytes[idx]
+			i--
+		}
+		cache >>= letterIdxBits
+		remain--
+	}
+
+	return string(b)
+}

--- a/internal/app/url.go
+++ b/internal/app/url.go
@@ -9,6 +9,7 @@ const (
 	letterIdxMax  = 63 / letterIdxBits   // # of letter indices fitting in 63 bits
 )
 
+// RandString generates randomised n letter string
 func RandString(n int) string {
 	b := make([]byte, n)
 	// A rand.Int63() generates 63 random bits, enough for letterIdxMax letters!

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,40 @@
+package config
+
+import "flag"
+
+type Flags struct {
+	Addr     *string
+	BaseAddr *string
+}
+
+func ParseFlags() Flags {
+	var flags Flags
+
+	flags.Addr = flag.String("a", "localhost:8080", "address for HTTP-server (addr:port); default localhost:8080")
+	flags.BaseAddr = flag.String("b", "", "sets base address for all resulting short urls; if not set uses -a flag address")
+
+	flag.Parse()
+
+	// checking is -b flag was set
+	// if it's not, then flags.Addr used as base
+	if *flags.BaseAddr == "" {
+		baseAddr := "http://" + *flags.Addr + "/"
+		flags.BaseAddr = &baseAddr
+	}
+
+	return flags
+}
+
+type Config struct {
+	Addr     string
+	BaseAddr string
+}
+
+func New() Config {
+	flags := ParseFlags()
+
+	return Config{
+		Addr:     *flags.Addr,
+		BaseAddr: *flags.BaseAddr,
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,12 @@ func ParseFlags() Flags {
 		flags.BaseAddr = &baseAddr
 	}
 
+	// adding a trailing slash at the end of a base address
+	if (*flags.BaseAddr)[len(*flags.BaseAddr)-1:] != "/" {
+		baseAddr := *flags.BaseAddr + "/"
+		flags.BaseAddr = &baseAddr
+	}
+
 	return flags
 }
 

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -3,12 +3,13 @@ package handlers
 import (
 	"github.com/go-chi/chi/v5"
 	"github.com/halviet/shortener/internal/app"
+	"github.com/halviet/shortener/internal/config"
 	"github.com/halviet/shortener/internal/storage"
 	"io"
 	"net/http"
 )
 
-func ShortenURLHandle(store *storage.Store) http.HandlerFunc {
+func ShortenURLHandle(store *storage.Store, cfg config.Config) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
 		resp, err := io.ReadAll(r.Body)
@@ -21,7 +22,7 @@ func ShortenURLHandle(store *storage.Store) http.HandlerFunc {
 		}
 
 		urlID := app.RandString(8)
-		url := "http://localhost:8080/" + urlID
+		url := cfg.BaseAddr + urlID
 
 		store.SaveURL(storage.ShortURL{
 			Origin: string(resp),

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -1,0 +1,42 @@
+package handlers
+
+import (
+	"io"
+	"net/http"
+)
+
+func ShortenURLHandle(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Only POST requests are allowed!", http.StatusMethodNotAllowed)
+		return
+	}
+
+	defer r.Body.Close()
+	resp, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+	}
+
+	if len(resp) < 11 {
+		http.Error(w, "Bad Request", http.StatusBadRequest)
+	}
+
+	w.WriteHeader(http.StatusCreated)
+	w.Write([]byte("https://localhost:8080/EwHXdJfB"))
+}
+
+func GetURLHandle(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Only GET requests are allowed!", http.StatusMethodNotAllowed)
+		return
+	}
+
+	if r.PathValue("id") == "EwHXdJfB" {
+		w.Header().Set("Location", "https://practicum.yandex.ru/")
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusTemporaryRedirect)
+		return
+	}
+
+	http.Error(w, "Incorrect request", http.StatusBadRequest)
+}

--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -2,6 +2,11 @@ package handlers
 
 import (
 	"bytes"
+	"github.com/go-chi/chi/v5"
+	"github.com/halviet/shortener/internal/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -32,24 +37,19 @@ func TestShortenURLHandle(t *testing.T) {
 			"http://i.io",
 			want{http.StatusCreated},
 		},
-		{
-			"provided not a url",
-			"Hello World!",
-			want{http.StatusBadRequest},
-		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			r := httptest.NewRequest(http.MethodPost, "/", bytes.NewBuffer([]byte(test.body)))
 			w := httptest.NewRecorder()
-			ShortenURLHandle(w, r)
+			ShortenURLHandle(&storage.Store{})(w, r)
 
 			res := w.Result()
 			defer res.Body.Close()
 			//resBody, err := io.ReadAll(res.Body)
 
-			assertStatusCode(t, res.StatusCode, test.want.statusCode)
+			assert.Equal(t, test.want.statusCode, res.StatusCode)
 		})
 	}
 }
@@ -57,47 +57,58 @@ func TestShortenURLHandle(t *testing.T) {
 func TestGetURLHandle(t *testing.T) {
 	type want struct {
 		statusCode int
-		locHeader  string
+		origin     string
 	}
 
 	tests := []struct {
-		name    string
-		request string
-		want    want
+		name  string
+		urlID string
+		want  want
 	}{
 		{
 			"correct request",
-			"EwHXdJfB",
+			"qVYlmrQn",
 			want{http.StatusTemporaryRedirect, "https://practicum.yandex.ru/"},
 		},
 	}
 
+	store := storage.New()
 	for _, test := range tests {
-		r := httptest.NewRequest(http.MethodGet, "/"+test.request, nil)
-		r.SetPathValue("id", test.request)
-		w := httptest.NewRecorder()
-		GetURLHandle(w, r)
+		store.SaveURL(storage.ShortURL{
+			Origin: test.want.origin,
+			Short:  test.urlID,
+		})
+	}
 
-		res := w.Result()
+	r := chi.NewRouter()
+	r.Get("/{id}", GetURLHandle(store))
 
-		assertStatusCode(t, res.StatusCode, test.want.statusCode)
+	ts := httptest.NewServer(r)
+	ts.Client().CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
 
-		loc := res.Header.Get("Location")
+	defer ts.Close()
 
-		if loc == "" {
-			t.Error("no Location header was provided by server")
-		}
-
-		if loc != test.want.locHeader {
-			t.Errorf("incorrect Location header: got %q; want %q", loc, test.want.locHeader)
-		}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			resp, _ := testGetRequest(t, ts, http.MethodGet, test.urlID)
+			assert.Equal(t, test.want.statusCode, resp.StatusCode)
+			assert.Equal(t, test.want.origin, resp.Header.Get("Location"))
+		})
 	}
 }
 
-func assertStatusCode(t testing.TB, got, want int) {
-	t.Helper()
+func testGetRequest(t *testing.T, ts *httptest.Server, method, path string) (*http.Response, string) {
+	req, err := http.NewRequest(method, ts.URL+"/"+path, nil)
+	require.NoError(t, err)
 
-	if got != want {
-		t.Errorf("unexpected status code: got %d; want %d", got, want)
-	}
+	resp, err := ts.Client().Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	return resp, string(respBody)
 }

--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"bytes"
 	"github.com/go-chi/chi/v5"
+	"github.com/halviet/shortener/internal/config"
 	"github.com/halviet/shortener/internal/storage"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -43,11 +44,10 @@ func TestShortenURLHandle(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			r := httptest.NewRequest(http.MethodPost, "/", bytes.NewBuffer([]byte(test.body)))
 			w := httptest.NewRecorder()
-			ShortenURLHandle(&storage.Store{})(w, r)
+			ShortenURLHandle(&storage.Store{}, config.Config{BaseAddr: "http://localhost:8080"})(w, r)
 
 			res := w.Result()
 			defer res.Body.Close()
-			//resBody, err := io.ReadAll(res.Body)
 
 			assert.Equal(t, test.want.statusCode, res.StatusCode)
 		})

--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -1,0 +1,103 @@
+package handlers
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestShortenURLHandle(t *testing.T) {
+	type want struct {
+		statusCode int
+	}
+
+	tests := []struct {
+		name string
+		body string
+		want want
+	}{
+		{
+			"correct request",
+			"https://practicum.yandex.ru/",
+			want{http.StatusCreated},
+		},
+		{
+			"empty request body",
+			"",
+			want{http.StatusBadRequest},
+		},
+		{
+			"provided very short url",
+			"http://i.io",
+			want{http.StatusCreated},
+		},
+		{
+			"provided not a url",
+			"Hello World!",
+			want{http.StatusBadRequest},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodPost, "/", bytes.NewBuffer([]byte(test.body)))
+			w := httptest.NewRecorder()
+			ShortenURLHandle(w, r)
+
+			res := w.Result()
+			defer res.Body.Close()
+			//resBody, err := io.ReadAll(res.Body)
+
+			assertStatusCode(t, res.StatusCode, test.want.statusCode)
+		})
+	}
+}
+
+func TestGetURLHandle(t *testing.T) {
+	type want struct {
+		statusCode int
+		locHeader  string
+	}
+
+	tests := []struct {
+		name    string
+		request string
+		want    want
+	}{
+		{
+			"correct request",
+			"EwHXdJfB",
+			want{http.StatusTemporaryRedirect, "https://practicum.yandex.ru/"},
+		},
+	}
+
+	for _, test := range tests {
+		r := httptest.NewRequest(http.MethodGet, "/"+test.request, nil)
+		r.SetPathValue("id", test.request)
+		w := httptest.NewRecorder()
+		GetURLHandle(w, r)
+
+		res := w.Result()
+
+		assertStatusCode(t, res.StatusCode, test.want.statusCode)
+
+		loc := res.Header.Get("Location")
+
+		if loc == "" {
+			t.Error("no Location header was provided by server")
+		}
+
+		if loc != test.want.locHeader {
+			t.Errorf("incorrect Location header: got %q; want %q", loc, test.want.locHeader)
+		}
+	}
+}
+
+func assertStatusCode(t testing.TB, got, want int) {
+	t.Helper()
+
+	if got != want {
+		t.Errorf("unexpected status code: got %d; want %d", got, want)
+	}
+}

--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -93,6 +93,7 @@ func TestGetURLHandle(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			resp, _ := testGetRequest(t, ts, http.MethodGet, test.urlID)
+			defer resp.Body.Close()
 			assert.Equal(t, test.want.statusCode, resp.StatusCode)
 			assert.Equal(t, test.want.origin, resp.Header.Get("Location"))
 		})

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -1,0 +1,1 @@
+package middleware

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -1,6 +1,35 @@
 package storage
 
+import "fmt"
+
 type Storage interface {
-	CreateURL(origin string) (url string)
-	GetURL(url string) (origin string)
+	SaveURL(shortURL, origin string)
+	GetOrigin(shortURL string) (origin string)
+}
+
+type ShortURL struct {
+	Origin string
+	Short  string
+}
+
+func New() *Store {
+	return &Store{}
+}
+
+type Store struct {
+	urls []ShortURL
+}
+
+func (s *Store) SaveURL(url ShortURL) {
+	s.urls = append(s.urls, url)
+}
+
+func (s *Store) GetOrigin(shortURL string) (origin string, err error) {
+	for _, url := range s.urls {
+		if url.Short == shortURL {
+			return url.Origin, nil
+		}
+	}
+
+	return "", fmt.Errorf("url not found")
 }

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -1,0 +1,6 @@
+package storage
+
+type Storage interface {
+	CreateURL(origin string) (url string)
+	GetURL(url string) (origin string)
+}


### PR DESCRIPTION
Added support for flags.

- `-a [address]` - sets an address for HTTP server to run on;
- `-b [address]` - base address that will be returned from server after requesting url shortening.